### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/mhthorup/0fdbee33-c64f-4e32-b811-aa92690f58d0/000ce5b4-412d-44eb-9b2f-f2333cab2bc6/_apis/work/boardbadge/f765f873-a768-4624-812f-d2b62fa1f8f1)](https://dev.azure.com/mhthorup/0fdbee33-c64f-4e32-b811-aa92690f58d0/_boards/board/t/000ce5b4-412d-44eb-9b2f-f2333cab2bc6/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/mhthorup/0fdbee33-c64f-4e32-b811-aa92690f58d0/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.